### PR TITLE
feat: add error message, continue process if error raised

### DIFF
--- a/scripts/autorun/reframework-d2d.lua
+++ b/scripts/autorun/reframework-d2d.lua
@@ -14,6 +14,12 @@ re.on_draw_ui(
         if changed then 
             cfg.max_update_rate = value 
         end
+
+        local last_error = d2d.detail.get_last_script_error()
+        if last_error ~= "" then
+            imgui.text("Last Script Error:")
+            imgui.text_colored(last_error, 0xFF0000FF)
+        end
     end
 )
 


### PR DESCRIPTION
This change aims to fix two problems:
1. draw function errors are raised silently, devs/users have no way to know which script causes this
2. a single script error will block all draw functions