### PR TITLE
feat: add support for loading custom fonts from files

### DIFF
--- a/src/D2DFont.cpp
+++ b/src/D2DFont.cpp
@@ -3,13 +3,91 @@
 #include "utf8.h"
 
 #include "D2DFont.hpp"
+#include "reframework/API.hpp"
 
-D2DFont::D2DFont(ComPtr<IDWriteFactory> dwrite, const std::string& name, int size, bool bold, bool italic)
+D2DFont::D2DFont(ComPtr<IDWriteFactory5> dwrite, const std::string& family, int size, bool bold, bool italic)
     : m_dwrite{dwrite} {
-    std::wstring wide_name{};
-    utf8::utf8to16(name.begin(), name.end(), std::back_inserter(wide_name));
+    std::wstring wide_family{};
+    utf8::utf8to16(family.begin(), family.end(), std::back_inserter(wide_family));
 
-    if (FAILED(m_dwrite->CreateTextFormat(wide_name.c_str(), nullptr, bold ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL,
+    if (FAILED(m_dwrite->CreateTextFormat(wide_family.c_str(), nullptr, bold ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL,
+            italic ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, size, L"en-us", &m_format))) {
+        throw std::runtime_error{"Failed to create DWrite text format"};
+    }
+}
+
+D2DFont::D2DFont(
+    ComPtr<IDWriteFactory5> dwrite, std::filesystem::path filepath, const std::string& family, int size, bool bold, bool italic)
+    : m_dwrite{dwrite} {
+    ComPtr<IDWriteFontSetBuilder1> fontSetBuilder;
+    if (FAILED(m_dwrite->CreateFontSetBuilder(&fontSetBuilder))) {
+        throw std::runtime_error{"Failed to create DWrite font set builder"};
+    }
+
+    if (FAILED(m_dwrite->CreateFontFileReference(filepath.c_str(), nullptr, &m_fontFile))) {
+        throw std::runtime_error{"Failed to create font file reference"};
+    }
+
+    /* BOOL supported;
+    DWRITE_FONT_FILE_TYPE ftype;
+    UINT32 facecount;
+    m_fontFile->Analyze(&supported, &ftype, nullptr, &facecount);
+    if (!supported) {
+        throw std::runtime_error{"Unsupported font file"};
+    }
+
+    for (UINT32 i = 0; i < facecount; ++i) {
+        ComPtr<IDWriteFontFaceReference> ffref;
+        if (FAILED(m_dwrite->CreateFontFaceReference(m_fontFile.Get(), i, DWRITE_FONT_SIMULATIONS_NONE, &ffref))) {
+            throw std::runtime_error{"Failed to create font face reference"};
+        }
+        if (FAILED(m_fontSetBuilder->AddFontFaceReference(ffref.Get()))) {
+            throw std::runtime_error{"Failed to add font face reference"};
+        }
+    }*/
+
+    fontSetBuilder->AddFontFile(m_fontFile.Get());
+
+    ComPtr<IDWriteFontSet> fontSet;
+    if (FAILED(fontSetBuilder->CreateFontSet(&fontSet))) {
+        throw std::runtime_error{"Failed to create font set"};
+    }
+
+    if (FAILED(m_dwrite->CreateFontCollectionFromFontSet(fontSet.Get(), &m_fontCollection))) {
+        throw std::runtime_error{"Failed to create font collection from font set"};
+    }
+
+    std::wstring wide_family;
+    if (!family.empty()) {
+        utf8::utf8to16(family.begin(), family.end(), std::back_inserter(wide_family));
+    } else {
+        for (auto i = 0; i < m_fontCollection->GetFontFamilyCount(); ++i) {
+            ComPtr<IDWriteFontFamily1> fontFamily;
+            if (FAILED(m_fontCollection->GetFontFamily(i, &fontFamily))) {
+                throw std::runtime_error{"IDWriteFontCollection1::GetFontFamily failed"};
+            }
+            ComPtr<IDWriteLocalizedStrings> names;
+            if (FAILED(fontFamily->GetFamilyNames(&names))) {
+                throw std::runtime_error{"IDWriteFontFamily1::GetFamilyNames failed"};
+            }
+            UINT32 idx;
+            BOOL exists;
+            if (FAILED(names->FindLocaleName(L"en-us", &idx, &exists)) || !exists) {
+                throw std::runtime_error{"Can't find en-us name for font family"};
+            }
+            UINT32 len;
+            if (FAILED(names->GetStringLength(idx, &len))) {
+                throw std::runtime_error{"IDWriteLocalizedStrings::GetStringLength failed"};
+            }
+            wide_family.resize(len + 1, L'\0');
+            names->GetString(idx, wide_family.data(), wide_family.size());
+        }
+    }
+
+    reframework::API::get()->log_info("[reframework-d2d] [D2DFont] Chose family %S for font %S", wide_family.c_str(), filepath.filename().c_str() );
+
+    if (FAILED(m_dwrite->CreateTextFormat(wide_family.c_str(), m_fontCollection.Get(),
+            bold ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL,
             italic ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, size, L"en-us", &m_format))) {
         throw std::runtime_error{"Failed to create DWrite text format"};
     }

--- a/src/D2DFont.hpp
+++ b/src/D2DFont.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <tuple>
 
 #include <d2d1.h>
 #include <dwrite.h>
+#include <dwrite_3.h>
 #include <wrl.h>
 
 #include "LruCache.hpp"
@@ -13,13 +15,16 @@ class D2DFont {
 public:
     template <typename T> using ComPtr = Microsoft::WRL::ComPtr<T>;
 
-    D2DFont(ComPtr<IDWriteFactory> dwrite, const std::string& name, int size, bool bold, bool italic);
+    D2DFont(ComPtr<IDWriteFactory5> dwrite, const std::string& family, int size, bool bold, bool italic);
+    D2DFont(ComPtr<IDWriteFactory5> dwrite, std::filesystem::path filepath, const std::string& family, int size, bool bold, bool italic);
 
     ComPtr<IDWriteTextLayout> layout(const std::string& text);
     std::tuple<float, float> measure(const std::string& text);
 
 private:
-    ComPtr<IDWriteFactory> m_dwrite{};
+    ComPtr<IDWriteFactory5> m_dwrite{};
+    ComPtr<IDWriteFontFile> m_fontFile{};
+    ComPtr<IDWriteFontCollection1> m_fontCollection{};
     ComPtr<IDWriteTextFormat> m_format{};
     LruCache<std::string, ComPtr<IDWriteTextLayout>> m_layouts{100};
 };

--- a/src/D2DPainter.cpp
+++ b/src/D2DPainter.cpp
@@ -35,7 +35,7 @@ D2DPainter::D2DPainter(ID3D11Device* device, IDXGISurface* surface) {
         throw std::runtime_error{"Failed to create D2D brush"};
     }
 
-    if (FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dwrite))) {
+    if (FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory5), &m_dwrite))) {
         throw std::runtime_error{"Failed to create DWrite factory"};
     }
 

--- a/src/D2DPainter.hpp
+++ b/src/D2DPainter.hpp
@@ -59,6 +59,6 @@ private:
     ComPtr<ID2D1Bitmap1> m_rt{};
     ComPtr<ID2D1SolidColorBrush> m_brush{};
 
-    ComPtr<IDWriteFactory> m_dwrite{};
+    ComPtr<IDWriteFactory5> m_dwrite{};
     ComPtr<IWICImagingFactory> m_wic{};
 };


### PR DESCRIPTION
Implements loading fonts from custom files inside `/reframework/fonts.`
A dot in the first parameter treats it as a file.
If second parameter is a number (size), loads the last en-us compatible family in the file. 99% of font files have only one family anyway, so this default suffices in most cases.
`d2d.Font.new("NotoSansBold.ttf", 24)`
However an optional second string parameter can be used to assign the family name to load from within the file explicitly.
`d2d.Font.new("UDDigiKyokashoN-R.ttc", "UD デジタル 教科書体 N-R", 24)`
