### PR TITLE
feat(ci): Update GitHub Actions workflow to package and release build artifacts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,18 +16,61 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Configure CMake
-        run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-        
+
       - name: Install
         run: cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --prefix ${{github.workspace}}/install
 
-      - name: Upload artifacts
+      - name: Organize release files
+        run: |
+          mkdir -p ${{github.workspace}}\artifacts\
+          xcopy /Y "${{github.workspace}}\install\bin\*" "${{github.workspace}}\artifacts\"
+          xcopy /Y "${{github.workspace}}\scripts\autorun\reframework-d2d.lua" "${{github.workspace}}\artifacts\"
+        shell: cmd
+
+      - name: Upload artifacts (DLL and Lua)
         uses: actions/upload-artifact@v4.3.1
         with:
           name: REFramework-D2D
-          path: ${{github.workspace}}/install/bin/*
+          path: |
+            ${{github.workspace}}\artifacts\*
           if-no-files-found: error
 
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download built artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: REFramework-D2D
+          path: ${{github.workspace}}/release-temp
+
+      - name: Organize release files
+        run: |
+          mkdir -p ${{github.workspace}}/release/reframework/plugins/
+          mkdir -p ${{github.workspace}}/release/reframework/autorun/
+          mv ${{github.workspace}}/release-temp/reframework-d2d.dll ${{github.workspace}}/release/reframework/plugins/
+          mv ${{github.workspace}}/release-temp/reframework-d2d.lua ${{github.workspace}}/release/reframework/autorun/
+        shell: bash
+
+      - name: Package release files
+        run: |
+          cd ${{github.workspace}}/release
+          zip -r REFramework-D2D.zip reframework
+        shell: bash
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{github.workspace}}/release/REFramework-D2D.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the previous artifact handling and introduces a new release process. The artifact now includes all build outputs along with the `reframework-d2d.lua` script. The release workflow then organizes these files into the correct structure, allowing users to download fully usable plugins directly from the release page, automating the entire release process.

Let me know if any refinements are needed!